### PR TITLE
Switch tui dependency to ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -555,6 +555,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,25 +763,12 @@ dependencies = [
  "lofty",
  "once_cell",
  "rand",
+ "ratatui",
  "serde",
  "serde_json",
  "serde_yaml",
- "tui",
  "unicode-width",
  "webbrowser",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ default = ["clip"]
 clip = ["clipboard"]
 
 [dependencies]
-tui = "0.19"
-crossterm = "0.25"
+tui = { version = "0.20", package = "ratatui" }
+crossterm = "0.26"
 
 # libmpv isn't working for mpv v0.35 :(
 # So I'm using a fork :)

--- a/src/app/app_screen/mod.rs
+++ b/src/app/app_screen/mod.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::{command, error::Result, events, util::RectContains};
 
 mod now_playing;
@@ -94,7 +96,7 @@ impl<'a> AppScreen<'a> {
         Ok(())
     }
 
-    fn subcomponent_chunks(&self, frame: Rect) -> Vec<Rect> {
+    fn subcomponent_chunks(&self, frame: Rect) -> Rc<[Rect]> {
         Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(20), Constraint::Length(2)].as_ref())

--- a/src/app/browse_screen/mod.rs
+++ b/src/app/browse_screen/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 
 use crossterm::event::{KeyCode, MouseEvent, MouseEventKind};
 
+use std::rc::Rc;
 use std::borrow::Cow;
 use tui::layout::Rect;
 use tui::style::Color;
@@ -358,7 +359,7 @@ impl<'a> BrowseScreen<'a> {
         }
     }
 
-    fn subcomponent_chunks(&self, chunk: Rect) -> Vec<Rect> {
+    fn subcomponent_chunks(&self, chunk: Rect) -> Rc<[Rect]> {
         Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(15), Constraint::Percentage(85)].as_ref())


### PR DESCRIPTION
This is the actively maintained fork of `tui`: https://github.com/tui-rs-revival/ratatui