### PR TITLE
Add desktop file

### DIFF
--- a/contrib/tori.desktop
+++ b/contrib/tori.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=tori
+GenericName=Music player
+Comment=The frictionless music player for the terminal
+Icon=tori
+TryExec=tori
+Exec=tori
+Terminal=true
+Categories=AudioVideo;Audio;Player;ConsoleOnly;


### PR DESCRIPTION
Thought it would be nice to launch tori from a system launcher. Tested only the desktop file, but it should work nicely with `assets/tori.svg` as an icon.