### PR TITLE
feat: add feature of rename playlists

### DIFF
--- a/tori/src/app/browse_screen/playlists.rs
+++ b/tori/src/app/browse_screen/playlists.rs
@@ -12,8 +12,8 @@ use crate::{
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEventKind};
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::ExecutableCommand;
-use std::io;
 use std::result::Result as StdResult;
+use std::io;
 use tui::{
     layout::{self, Rect},
     style::{Color, Style},


### PR DESCRIPTION
Implements the code necessary to #24 rename playlists, works very similar to previous methods such as `RenameSong` and `CreatePlaylists`, it already treat problems such as empty playlist name, and new name already in another playlist, and returns the through the notifications at bottom.

A gif using this feature:

![tori](https://github.com/LeoRiether/tori/assets/85769349/d2a88522-3877-4bdf-bcf5-d1463dd52a0e)

I faced difficulties adding tests for playlist renaming without depending on other parts of the program, for example what would be the ideal way to create an isolated playlist only for testing and trigger/access the `app`  properties without violate the already implemented code.
