### PR TITLE
Refactor modals

### DIFF
--- a/tori/src/app/mod.rs
+++ b/tori/src/app/mod.rs
@@ -104,7 +104,7 @@ impl<'a> App<'a> {
             crossterm_event = channel.crossterm_rx.recv() => {
                 if let Some(ev) = crossterm_event {
                     let mut state = state.lock().await;
-                    match handle_event(&mut state, ev) {
+                    match handle_event(&mut state, channel.tx.clone(), ev) {
                         Ok(Some(a)) => channel.tx.send(a).expect("Failed to send action"),
                         Ok(None) => {}
                         Err(e) => state.notify_err(e.to_string()),

--- a/tori/src/app/modal/confirmation_modal.rs
+++ b/tori/src/app/modal/confirmation_modal.rs
@@ -1,4 +1,4 @@
-use super::{get_modal_chunk, Message, Modal};
+use super::{get_modal_chunk, Modal};
 
 use crossterm::event::{Event, KeyCode};
 use tui::{
@@ -8,39 +8,56 @@ use tui::{
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
 };
 
-use crate::error::Result;
+use crate::{
+    error::Result,
+    events::{channel::Tx, Action},
+};
 
 /// A confirmation modal box that asks for user yes/no input
 #[derive(Debug, Default)]
-pub struct ConfirmationModal {
+pub struct ConfirmationModal<C> {
     title: String,
     style: Style,
+    on_yes: Option<C>,
 }
 
-impl ConfirmationModal {
+impl<C> ConfirmationModal<C> {
     pub fn new(title: &str) -> Self {
         Self {
             title: format!("\n{} (y/n)", title),
             style: Style::default().fg(Color::LightBlue),
+            on_yes: None,
         }
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn on_yes(mut self, action: C) -> Self {
+        self.on_yes = Some(action);
+        self
     }
 }
 
-impl Modal for ConfirmationModal {
-    fn apply_style(&mut self, style: Style) {
-        self.style = style;
-    }
-
-    fn handle_event(&mut self, event: Event) -> Result<Message> {
+impl<C> Modal for ConfirmationModal<C>
+where
+    C: FnOnce() -> Action + Send + Sync,
+{
+    fn handle_event(&mut self, tx: Tx, event: Event) -> Result<Option<Action>> {
         use KeyCode::*;
         if let Event::Key(event) = event {
-            return match event.code {
-                Backspace | Esc | Char('q') | Char('n') | Char('N') => Ok(Message::Quit),
-                Enter | Char('y') | Char('Y') => Ok(Message::Commit("y".into())),
-                _ => Ok(Message::Nothing),
-            };
+            return Ok(match event.code {
+                Backspace | Esc | Char('q') | Char('n') | Char('N') => Some(Action::CloseModal),
+                Enter | Char('y') | Char('Y') => {
+                    tx.send(Action::CloseModal);
+                    self.on_yes.take().map(|f| f())
+                }
+                _ => None,
+            });
         }
-        Ok(Message::Nothing)
+        Ok(None)
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {

--- a/tori/src/app/modal/confirmation_modal.rs
+++ b/tori/src/app/modal/confirmation_modal.rs
@@ -60,8 +60,4 @@ impl Modal for ConfirmationModal {
         Clear.render(chunk, buf);
         paragraph.render(chunk, buf);
     }
-
-    fn mode(&self) -> ! {
-        todo!()
-    }
 }

--- a/tori/src/app/modal/help_modal.rs
+++ b/tori/src/app/modal/help_modal.rs
@@ -1,19 +1,19 @@
-use super::{get_modal_chunk, Message, Modal};
+use super::Modal;
 
 use crossterm::event::Event;
 use tui::{
     layout::{Alignment, Constraint},
+    prelude::*,
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Row, Table, Widget},
-    prelude::*,
 };
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
     config::{shortcuts::InputStr, Config},
     error::Result,
-    events::Command,
+    events::{channel::Tx, Action, Command},
 };
 
 /// A modal box that asks for user input
@@ -60,19 +60,21 @@ impl HelpModal {
 }
 
 impl Modal for HelpModal {
-    fn apply_style(&mut self, _style: Style) {}
-
-    fn handle_event(&mut self, event: Event) -> Result<Message> {
+    fn handle_event(&mut self, tx: Tx, event: Event) -> Result<Option<Action>> {
         if let Event::Key(_) = event {
-            return Ok(Message::Quit);
+            return Ok(Some(Action::CloseModal));
         }
-        Ok(Message::Nothing)
+        Ok(None)
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let mut chunk = get_modal_chunk(area);
-        chunk.y = 3;
-        chunk.height = area.height.saturating_sub(6);
+        let width = (area.width / 2).max(70).min(area.width);
+        let mut chunk = Rect {
+            x: area.width.saturating_sub(width) / 2,
+            width,
+            y: 3,
+            height: area.height.saturating_sub(6),
+        };
 
         let block = Block::default()
             .title(" Help ")

--- a/tori/src/app/modal/help_modal.rs
+++ b/tori/src/app/modal/help_modal.rs
@@ -100,8 +100,4 @@ impl Modal for HelpModal {
         chunk.height -= 3;
         table.render(chunk, buf);
     }
-
-    fn mode(&self) -> ! {
-        todo!()
-    }
 }

--- a/tori/src/app/modal/hotkey_modal.rs
+++ b/tori/src/app/modal/hotkey_modal.rs
@@ -1,20 +1,18 @@
 use crate::{
     config::shortcuts::InputStr,
     error::Result,
+    events::{channel::Tx, Action},
 };
-use crossterm::event::Event as CrosstermEvent;
+use crossterm::event::{Event, KeyCode};
 use tui::{
     layout::Alignment,
+    prelude::*,
     style::{Color, Style},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
-    prelude::*,
 };
 
 use super::Modal;
 
-///////////////////////////////
-//        HotkeyModal        //
-///////////////////////////////
 /// Shows what keys the user is pressing
 #[derive(Debug, Default)]
 pub struct HotkeyModal {
@@ -22,16 +20,14 @@ pub struct HotkeyModal {
 }
 
 impl Modal for HotkeyModal {
-    fn apply_style(&mut self, _style: Style) {}
-
-    fn handle_event(&mut self, event: CrosstermEvent) -> Result<super::Message> {
-        if let CrosstermEvent::Key(key) = event {
-            if let crossterm::event::KeyCode::Esc = key.code {
-                return Ok(super::Message::Quit);
+    fn handle_event(&mut self, tx: Tx, event: Event) -> Result<Option<Action>> {
+        if let Event::Key(key) = event {
+            if let KeyCode::Esc = key.code {
+                return Ok(Some(Action::CloseModal));
             }
             self.text = InputStr::from(key).0;
         }
-        Ok(super::Message::Nothing)
+        Ok(None)
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {

--- a/tori/src/app/modal/hotkey_modal.rs
+++ b/tori/src/app/modal/hotkey_modal.rs
@@ -53,8 +53,4 @@ impl Modal for HotkeyModal {
         Clear.render(chunk, buf);
         paragraph.render(chunk, buf);
     }
-
-    fn mode(&self) -> ! {
-        todo!()
-    }
 }

--- a/tori/src/app/modal/input_modal.rs
+++ b/tori/src/app/modal/input_modal.rs
@@ -137,10 +137,6 @@ impl<'t> Modal for InputModal<'t> {
         Clear.render(chunk, buf);
         paragraph.render(chunk, buf);
     }
-
-    fn mode(&self) -> ! {
-        todo!()
-    }
 }
 
 impl<'t> InputModal<'t> {

--- a/tori/src/app/modal/mod.rs
+++ b/tori/src/app/modal/mod.rs
@@ -40,7 +40,6 @@ where
     fn apply_style(&mut self, style: Style);
     fn handle_event(&mut self, event: Event) -> Result<Message>;
     fn render(&self, area: Rect, buf: &mut Buffer);
-    fn mode(&self) -> !;
 }
 
 impl Default for Box<dyn Modal> {

--- a/tori/src/app/modal/mod.rs
+++ b/tori/src/app/modal/mod.rs
@@ -4,47 +4,28 @@ pub mod hotkey_modal;
 pub mod input_modal;
 
 pub use confirmation_modal::ConfirmationModal;
-use crossterm::event::Event;
 pub use help_modal::HelpModal;
 pub use hotkey_modal::HotkeyModal;
 pub use input_modal::InputModal;
 
-use tui::{layout::Rect, prelude::*, style::Style};
+use crate::{
+    error::Result,
+    events::{channel::Tx, Action},
+};
+use crossterm::event::Event;
+use tui::{layout::Rect, prelude::*};
 
-use crate::error::Result;
-
-///////////////////////////////////////////////////
-//                    Message                    //
-///////////////////////////////////////////////////
-/// The return type for [Modal::handle_event].
-#[derive(Debug, Default, PartialEq)]
-pub enum Message {
-    /// Nothing changed
-    #[default]
-    Nothing,
-
-    /// User has quit the modal (by pressing Esc)
-    Quit,
-
-    /// User has written something (the String) in the modal and pressed Enter
-    Commit(String),
-}
-
-/////////////////////////////////////////////////
-//                    Modal                    //
-/////////////////////////////////////////////////
 pub trait Modal
 where
     Self: Sync + Send,
 {
-    fn apply_style(&mut self, style: Style);
-    fn handle_event(&mut self, event: Event) -> Result<Message>;
+    fn handle_event(&mut self, tx: Tx, event: Event) -> Result<Option<Action>>;
     fn render(&self, area: Rect, buf: &mut Buffer);
-}
-
-impl Default for Box<dyn Modal> {
-    fn default() -> Self {
-        Box::new(InputModal::new(String::default()))
+    fn some_box(self) -> Option<Box<dyn Modal>>
+    where
+        Self: Sized + 'static,
+    {
+        Some(Box::new(self))
     }
 }
 
@@ -59,76 +40,3 @@ pub fn get_modal_chunk(frame: Rect) -> Rect {
         height,
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crossterm::event::{
-//         Event::Key,
-//         KeyCode::{self, Backspace, Char, Enter, Esc},
-//         KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
-//     };
-//
-//     fn key_event(code: KeyCode) -> crossterm::event::Event {
-//         Key(KeyEvent {
-//             code,
-//             modifiers: KeyModifiers::NONE,
-//             kind: KeyEventKind::Press,
-//             state: KeyEventState::NONE,
-//         })
-//     }
-//
-//     #[test]
-//     fn test_modal_commit_lifecycle() {
-//         let mut modal = InputModal::new("commit lifecycle");
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Char('h'))))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Char('i'))))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Char('!'))))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Backspace)))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal.handle_event(Event::Terminal(key_event(Enter))).ok(),
-//             Some(Message::Commit("hi".into()))
-//         );
-//     }
-//
-//     #[test]
-//     fn test_modal_quit_lifecycle() {
-//         let mut modal = InputModal::new("commit lifecycle");
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Char('h'))))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal
-//                 .handle_event(Event::Terminal(key_event(Char('i'))))
-//                 .ok(),
-//             Some(Message::Nothing)
-//         );
-//         assert_eq!(
-//             modal.handle_event(Event::Terminal(key_event(Esc))).ok(),
-//             Some(Message::Quit)
-//         );
-//     }
-// }

--- a/tori/src/events/action.rs
+++ b/tori/src/events/action.rs
@@ -12,4 +12,5 @@ pub enum Action {
     RefreshPlaylists,
     SelectSong(usize),
     SelectPlaylist(usize),
+    CloseModal,
 }

--- a/tori/src/events/action.rs
+++ b/tori/src/events/action.rs
@@ -7,10 +7,36 @@ pub enum Action {
     ScrollDown,
     ScrollUp,
     Command(Command),
-    SongAdded { playlist: String, song: String },
     RefreshSongs,
     RefreshPlaylists,
     SelectSong(usize),
     SelectPlaylist(usize),
     CloseModal,
+    AddPlaylist {
+        name: String,
+    },
+    RenamePlaylist {
+        playlist: String,
+        new_name: String,
+    },
+    DeletePlaylist {
+        playlist: String,
+    },
+    AddSongToPlaylist {
+        playlist: String,
+        song: String,
+    },
+    SongAdded {
+        playlist: String,
+        song: String,
+    },
+    RenameSong {
+        playlist: String,
+        index: usize,
+        new_name: String,
+    },
+    DeleteSong {
+        playlist: String,
+        index: usize,
+    },
 }

--- a/tori/src/input.rs
+++ b/tori/src/input.rs
@@ -18,6 +18,13 @@ pub struct Input {
 }
 
 impl Input {
+    pub fn new(value: impl Into<String>) -> Input {
+        Input {
+            value: value.into(),
+            cursor: 0,
+        }
+    }
+
     pub fn handle_event(&mut self, key: KeyEvent) -> InputResponse {
         use KeyCode::*;
         match key.code {
@@ -137,5 +144,54 @@ impl<'a> Widget for InputWidget<'a> {
         }
 
         paragraph.render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_cursor_ascii() {
+        let mut input = Input::new("input cursor");
+        input.value = "Hello World!".into();
+        assert_eq!(input.cursor, 0);
+
+        input.move_cursor(1);
+        assert_eq!(input.cursor, 1);
+
+        input.move_cursor(1);
+        assert_eq!(input.cursor, 2);
+
+        input.move_cursor(-1);
+        assert_eq!(input.cursor, 1);
+
+        input.move_cursor(-1);
+        assert_eq!(input.cursor, 0);
+
+        input.move_cursor(-1);
+        assert_eq!(input.cursor, 0);
+
+        input.move_cursor(1000);
+        assert_eq!(input.cursor, input.value.len());
+    }
+
+    #[test]
+    fn test_input_cursor_unicode() {
+        let mut input = Input::new("input cursor");
+        input.value = "おはよう".into();
+        assert_eq!(input.cursor, 0);
+
+        input.move_cursor(1);
+        assert_eq!(input.cursor, 3);
+
+        input.move_cursor(1);
+        assert_eq!(input.cursor, 6);
+
+        input.move_cursor(-1);
+        assert_eq!(input.cursor, 3);
+
+        input.move_cursor(-1);
+        assert_eq!(input.cursor, 0);
     }
 }

--- a/tori/src/update/mod.rs
+++ b/tori/src/update/mod.rs
@@ -80,6 +80,10 @@ pub fn update(state: &mut State<'_>, tx: Tx, act: Action) -> Result<Option<Actio
                 state.notification = None;
             }
         }
+
+        CloseModal => {
+            state.modal = None;
+        }
     }
 
     Ok(None)

--- a/tori/src/update/mod.rs
+++ b/tori/src/update/mod.rs
@@ -6,14 +6,19 @@ use std::mem;
 use crate::{
     config::Config,
     error::Result,
-    events::{channel::Tx, Action, Command},
+    events::{action::Level, channel::Tx, Action, Command},
     input::InputResponse,
+    m3u::playlist_management,
     player::Player,
     state::{browse_screen::Focus, Screen, State},
 };
 use crossterm::event::{Event as TermEvent, KeyEvent, KeyEventKind, MouseEventKind};
 
-pub fn handle_event(state: &mut State<'_>, ev: TermEvent) -> Result<Option<Action>> {
+pub fn handle_event(state: &mut State<'_>, tx: Tx, ev: TermEvent) -> Result<Option<Action>> {
+    if let Some(modal) = &mut state.modal {
+        return modal.handle_event(tx, ev);
+    }
+
     Ok(match ev {
         TermEvent::Key(key) if key.kind != KeyEventKind::Release => match &mut state.screen {
             Screen::None => unreachable!(),
@@ -81,8 +86,71 @@ pub fn update(state: &mut State<'_>, tx: Tx, act: Action) -> Result<Option<Actio
             }
         }
 
+        Notify(level, msg) => {
+            match level {
+                Level::Ok => state.notify_ok(msg),
+                Level::Info => state.notify_info(msg),
+                Level::Error => state.notify_err(msg),
+            };
+        }
+
         CloseModal => {
             state.modal = None;
+        }
+        AddPlaylist { name } => {
+            match playlist_management::create_playlist(&name) {
+                Ok(()) => state.notify_ok(format!("Playlist {name} created")),
+                Err(e) => state.notify_err(format!("Error creating playlist: {e:?}")),
+            };
+            return Ok(Some(Action::RefreshPlaylists));
+        }
+        RenamePlaylist { playlist, new_name } => {
+            match playlist_management::rename_playlist(&playlist, &new_name) {
+                Ok(()) => state.notify_ok(format!("Playlist {playlist} renamed to {new_name}")),
+                Err(e) => state.notify_err(format!("Error renaming playlist: {e:?}")),
+            }
+            return Ok(Some(Action::RefreshPlaylists));
+        }
+        DeletePlaylist { playlist } => {
+            match playlist_management::delete_playlist(&playlist) {
+                Ok(()) => state.notify_ok(format!("Playlist {playlist} deleted")),
+                Err(e) => state.notify_err(format!("Error deleting playlist: {e:?}")),
+            };
+            return Ok(Some(Action::RefreshPlaylists));
+        }
+        AddSongToPlaylist { playlist, song } => {
+            tokio::task::spawn(async move {
+                let res =
+                    playlist_management::add_song(tx.clone(), playlist.clone(), song.clone()).await;
+                match res {
+                    Ok(()) => tx
+                        .send(Action::Notify(
+                            Level::Info,
+                            format!("Added {song} to {playlist} playlist"),
+                        ))
+                        .ok(),
+                    Err(e) => tx.send(Notify(Level::Error, format!("{:?}", e))).ok(),
+                };
+                tx.send(RefreshSongs).ok();
+            });
+        }
+        RenameSong {
+            playlist,
+            index,
+            new_name,
+        } => {
+            match playlist_management::rename_song(&playlist, index, &new_name) {
+                Ok(()) => {}
+                Err(e) => state.notify_err(format!("Error renaming song: {e:?}")),
+            };
+            return Ok(Some(Action::RefreshSongs));
+        }
+        DeleteSong { playlist, index } => {
+            match playlist_management::delete_song(&playlist, index) {
+                Ok(()) => {}
+                Err(e) => state.notify_err(format!("Error deleting song: {e:?}")),
+            }
+            return Ok(Some(Action::RefreshSongs));
         }
     }
 
@@ -94,7 +162,9 @@ fn handle_command(state: &mut State<'_>, tx: Tx, cmd: Command) -> Result<Option<
     match cmd {
         Esc | Play | QueueSong | QueueShown | OpenInBrowser | CopyUrl | CopyTitle
         | NextSortingMode | SelectLeft | SelectNext | SelectRight | SelectPrev | Search
-        | GotoStart | GotoEnd => return screen_action(state, tx, Action::Command(cmd)),
+        | GotoStart | GotoEnd | Add | Rename | Delete => {
+            return screen_action(state, tx, Action::Command(cmd))
+        }
 
         Nop => {}
         Quit => {
@@ -154,9 +224,6 @@ fn handle_command(state: &mut State<'_>, tx: Tx, cmd: Command) -> Result<Option<
 
         OpenHelpModal => todo!(),
         OpenHotkeyModal => todo!(),
-        Add => todo!(),
-        Rename => todo!(),
-        Delete => todo!(),
         PlayFromModal => todo!(),
 
         SwapSongDown => todo!(),


### PR DESCRIPTION
Now modals receive a lambda that returns an Action. This makes modals infinitely more reusable than the previous ones. To illustrate, this is now possible:

```rust
let add_modal = Box::new(
    InputModal::new()
        .style(Style::default().fg(Color::BrightRed))
        .on_commit(|input| Action::AddSong(input))
);

let rename_modal = Box::new(
    InputModal::new()
        .style(Style::default().fg(Color::Blue))
        .on_commit(|input| Action::RenameSongTo(input))
);
```

No special case handling for each type of modal!

Also, modals now send Action::CloseModal when appropriate, which closes any open modal. Previously each modal had its own match case to close itself...